### PR TITLE
feat: implement credential oa plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ VCs exemplify a decentralsied model for high integrity digital data excahnge. Th
 
 If you are an organisation that issues any kind of credential such as a permit, certificate, accreditation, license, or other "claim" of value to your community or constituency, then this project is for you. vckit provides the tools to equip your existing business systems with the ability to issue your existing credentials as high integrity, standards based, and interoperable VCs that your constituents (VC holders) can present to any party that needs to verify them.
 
-VCs issued by vckit tooling can be verified using any mobile device camera to scan a QR code. This is important so that uptake can remain compatible with today's paper processes. There is no requirement for verifiers of credentials to adopt any new new technology in order to verify a credential. However, if you are an organisation that is likely to be verifying at scale or you wish to extract the digitial data in a credential for use in your business systems then vckit is also for you.  It provides an advanced multi-protocol verification capability that can be integrated with your systems.
+VCs issued by vckit tooling can be verified using any mobile device camera to scan a QR code. This is important so that uptake can remain compatible with today's paper processes. There is no requirement for verifiers of credentials to adopt any new new technology in order to verify a credential. However, if you are an organisation that is likely to be verifying at scale or you wish to extract the digitial data in a credential for use in your business systems then vckit is also for you. It provides an advanced multi-protocol verification capability that can be integrated with your systems.
 
 # Get Started
 

--- a/packages/core-types/src/index.ts
+++ b/packages/core-types/src/index.ts
@@ -8,6 +8,7 @@
 export { CoreEvents } from './coreEvents.js'
 export * from './agent.js'
 export * from './types/IAgent.js'
+export * from './types/IOACredentialPlugin.js'
 export * from './types/ICredentialPlugin.js'
 export * from './types/ICredentialIssuer.js'
 export * from './types/ICredentialVerifier.js'

--- a/packages/core-types/src/plugin.schema.json
+++ b/packages/core-types/src/plugin.schema.json
@@ -4213,7 +4213,7 @@
             "EthereumEip712Signature2021",
             "OpenAttestationMerkleProofSignature2018"
           ],
-          "description": "The type of encoding to be used for the Verifiable Credential or Presentation to be generated.\n\nOnly `jwt` and `lds` is supported at the moment."
+          "description": "The type of encoding to be used for the Verifiable Credential or Presentation to be generated.\n\nOnly `jwt` , `lds` and `OpenAttestationMerkleProofSignature2018` are supported at the moment."
         },
         "VerifiableCredential": {
           "type": "object",

--- a/packages/core-types/src/types/ICredentialIssuer.ts
+++ b/packages/core-types/src/types/ICredentialIssuer.ts
@@ -13,7 +13,7 @@ import { IKeyManager } from './IKeyManager.js'
 /**
  * The type of encoding to be used for the Verifiable Credential or Presentation to be generated.
  *
- * Only `jwt` and `lds` is supported at the moment.
+ * Only `jwt` , `lds` and `OpenAttestationMerkleProofSignature2018` are supported at the moment.
  *
  * @public
  */
@@ -198,8 +198,8 @@ export interface ICredentialIssuer extends IPluginMethodMap {
    */
   createVerifiableCredential(
     args: ICreateVerifiableCredentialArgs,
-    context: IssuerAgentContext,
-  ): Promise<VerifiableCredential>
+    context: IssuerAgentContext
+  ): Promise<VerifiableCredential>;
 }
 
 /**

--- a/packages/core-types/src/types/IOACredentialPlugin.ts
+++ b/packages/core-types/src/types/IOACredentialPlugin.ts
@@ -1,0 +1,49 @@
+import { IPluginMethodMap } from './IAgent';
+import { VerifiableCredential } from './vc-data-model';
+import {
+  ICreateVerifiableCredentialArgs,
+  IssuerAgentContext,
+} from './ICredentialIssuer';
+import {
+  IVerifyCredentialArgs,
+  VerifierAgentContext,
+} from './ICredentialVerifier';
+import { IVerifyResult } from './IVerifyResult';
+
+/**
+ * @public
+ */
+export interface IOACredentialPlugin extends IPluginMethodMap {
+  /**
+   * Creates a Verifiable Credential.
+   * The payload, signer and format are chosen based on the `args` parameter.
+   *
+   * @param args - Arguments necessary to create the Presentation.
+   * @param context - This reserved param is automatically added and handled by the framework, *do not override*
+   *
+   * @returns - a promise that resolves to the {@link @veramo/core-types#VerifiableCredential} that was requested or rejects
+   *   with an error if there was a problem with the input or while getting the key to sign
+   *
+   * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#credentials | Verifiable Credential data model}
+   */
+  createVerifiableCredentialOA(
+    args: ICreateVerifiableCredentialArgs,
+    context: IssuerAgentContext
+  ): Promise<VerifiableCredential>;
+
+  /**
+   * Verifies a Verifiable Credential Open Attestation Format.
+   *
+   * @param args - Arguments necessary to verify a VerifiableCredential
+   * @param context - This reserved param is automatically added and handled by the framework, *do not override*
+   *
+   * @returns - a promise that resolves to an object containing a `verified` boolean property and an optional `error`
+   *   for details
+   *
+   * @remarks Please see {@link https://www.w3.org/TR/vc-data-model/#credentials | Verifiable Credential data model}
+   */
+  verifyCredentialOA(
+    args: IVerifyCredentialArgs,
+    context: VerifierAgentContext
+  ): Promise<IVerifyResult>;
+}

--- a/packages/credential-oa/README.md
+++ b/packages/credential-oa/README.md
@@ -1,0 +1,60 @@
+# Credential OpenAttestation Plugin
+
+- This plugin is used for issuing and verifying verifiable credential that adhere to OpenAttestation framework
+- `uncefact/project-vckit` ’s goals is to support issuing and verifying verifiable credential in both W3C and OpenAtttestation framework right now , so this plugin is packed inside `uncefact/project-vckit` core but it can be plugged into any platform/library that using Veramo architecture.
+
+## Usage
+
+- Add this declaration to `agent.yml` config file
+
+```
+
+///... other declarations
+# Agent
+agent:
+  $require: '@vckit/core#Agent'
+  $args:
+    - schemaValidation: false
+      plugins:
+        /// ... other declarations
+        **- $require: '@vckit/credential-oa#CredentialPlugin'**
+```
+
+- **Signing**
+  - To streamline the signing process across signing process between w3c, OpenAttestation and other frameworks in mind , the plugin use private key that managed by Veramo’s keyManager to sign and associate with did document.
+  > **NOTE**: OpenAttestation document currently support 2 types of DID which is **did ethereum** and **did web**
+- **Using uncefact/project-vckit CLI to create an OpenAttestation verifiable credential**
+  - **Prerequisites:** create a new did document if you haven’t create one \*\*\*\*
+    - `pnpm run vckit did create`
+    - Select **did:ether** or **did:web**
+      - If you select **did:web,** it’s your responsibility to put the verification information to standard endpoint so that verifier can resolve and verify your document
+      - **Note**: Every did document created has a key associated with it , to add a new key , run `pnpm run vckit did add-key`
+    ```jsx
+    ? Select identifier provider (Use arrow keys)
+    ❯ did:ethr
+    ```
+    ### **Create OpenAttestation VC**
+    - Run: `pnpm run vckit credential create`
+      - Select `OpenAttestationMerkleProofSignature2018`
+      ```jsx
+      ? Credential proofFormat
+        jwt
+        lds
+        EthereumEip712Signature2021
+      ❯ OpenAttestationMerkleProofSignature2018
+      ```
+      - Select a did document you create earlier to identify issuer and sign document
+      ```jsx
+      Issuer DID
+      ❯ did:ethr:0x034bb92d2fffb6ff7ad8fbbefc01a919818017ef3f32c3e1443f44a45ab94f16bb
+      ```
+      - Select identity proof type
+        - **Note**: `DNS-DID` and `DNS-TXT` require you to put the Issuer DID information to the domain specified in Identity Proof Type. Refer to [this](https://www.openattestation.com/docs/integrator-section/verifiable-document/ethereum/dns-proof) for more information. For the `DID` , verification process will skip checking for the issuer information
+        ```jsx
+        ? Identity Proof Type (Use arrow keys)
+        ❯ DNS-DID
+          DNS-TXT
+          DID
+        ```
+    ### Verify **OpenAttestation VC**
+    - Simple run `pnpm run vckit verify -f vc-file.json` with the result from the create vc to verify the vc

--- a/packages/credential-oa/__tests__/action-handler.test.ts
+++ b/packages/credential-oa/__tests__/action-handler.test.ts
@@ -1,0 +1,125 @@
+import { jest } from '@jest/globals';
+
+import {
+  ICreateVerifiableCredentialArgs,
+  IssuerAgentContext,
+} from '@vckit/core-types';
+
+import { CredentialPlugin } from '../src';
+import { INVALID_RAW_OA_CREDENTIAL, RAW_OA_CREDENTIAL } from './mocks/constants';
+
+describe('CredentialPlugin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createVerifiableCredentialOA', () => {
+    it('should create a verifiable credential with valid inputs', async () => {
+      const credentialPlugin = new CredentialPlugin();
+      const args: ICreateVerifiableCredentialArgs = {
+        credential: RAW_OA_CREDENTIAL,
+        proofFormat: 'OpenAttestationMerkleProofSignature2018',
+      };
+
+      const signature = '0x0987';
+      const did = 'did:ethr:0xabc123';
+
+      const issuerAgentContext = {
+        agent: {
+          didManagerGet: jest.fn().mockReturnValue({
+            did,
+            keys: [
+              {
+                kid: 'kid',
+                type: 'Secp256k1',
+                kms: 'local',
+                publicKeyHex: 'test',
+              },
+            ],
+          }),
+          keyManagerSign: jest.fn().mockReturnValue(signature),
+        },
+      } as unknown as IssuerAgentContext;
+
+      const result = await credentialPlugin.createVerifiableCredentialOA(
+        args,
+        issuerAgentContext
+      );
+
+      expect(result).toBeDefined();
+      expect(result['@context']).toContain(
+        'https://www.w3.org/2018/credentials/v1'
+      );
+      expect(result.type).toContain('VerifiableCredential');
+      expect(result.type).toContain('OpenAttestationCredential');
+      expect(result.proof.signature).toEqual(signature);
+      expect(result.proof.key).toEqual(`${did}#controller`);
+    });
+
+    it('should throw an error if DID not managed by KMS', async () => {
+      const credentialPlugin = new CredentialPlugin();
+
+      const args: ICreateVerifiableCredentialArgs = {
+        credential: RAW_OA_CREDENTIAL,
+        proofFormat: 'OpenAttestationMerkleProofSignature2018',
+      };
+
+      const did = 'did:ethr:0xabc123';
+      const issuerAgentContext = {
+        agent: {
+          didManagerGet: jest.fn().mockReturnValue({
+            did,
+            keys: [
+              {
+                kid: 'kid',
+                type: 'Ed25519',
+                kms: 'local',
+                publicKeyHex: 'test',
+              },
+            ],
+          }),
+        },
+      } as unknown as IssuerAgentContext;
+
+      await expect(
+        credentialPlugin.createVerifiableCredentialOA(args, issuerAgentContext)
+      ).rejects.toThrow('No signing key for ' + did);
+    });
+
+
+    it('should throw an error if payload is not in OpenAttestation format', async () => {
+      const credentialPlugin = new CredentialPlugin();
+
+      const args: ICreateVerifiableCredentialArgs = {
+        credential: INVALID_RAW_OA_CREDENTIAL,
+        proofFormat: 'OpenAttestationMerkleProofSignature2018',
+      };
+
+      await expect(
+        credentialPlugin.createVerifiableCredentialOA(args, {} as IssuerAgentContext)
+      ).rejects.toThrow('invalid_argument: credential is not a valid OpenAttestation document');
+    });
+
+    it('should throw an error if key type is not Secp256k1', async () => {
+      const credentialPlugin = new CredentialPlugin();
+      const args: ICreateVerifiableCredentialArgs = {
+        credential: RAW_OA_CREDENTIAL,
+        proofFormat: 'OpenAttestationMerkleProofSignature2018',
+      };
+
+      const issuerAgentContext = {
+        agent: {
+          didManagerGet: jest.fn().mockImplementation(() => {
+            throw new Error();
+          }),
+        },
+      } as unknown as IssuerAgentContext;
+
+      await expect(
+        credentialPlugin.createVerifiableCredentialOA(args, issuerAgentContext)
+      ).rejects.toThrow(
+        'invalid_argument: did not found in the DID manager'
+      );
+    });
+  });
+});

--- a/packages/credential-oa/__tests__/mocks/constants.ts
+++ b/packages/credential-oa/__tests__/mocks/constants.ts
@@ -1,0 +1,130 @@
+export const RAW_OA_CREDENTIAL = {
+  issuer: {
+    id: 'did:ethr:0x02f6b75650805b93c9df9514e36302e8ad9ae1fbd8aeeb1163b7259dc2971dd3c2',
+    name: 'GoSource Pty Ltd',
+    type: 'OpenAttestationIssuer',
+  },
+  '@context': [
+    'https://www.w3.org/2018/credentials/v1',
+    'https://schemata.openattestation.com/com/openattestation/1.0/DrivingLicenceCredential.json',
+    'https://schemata.openattestation.com/com/openattestation/1.0/CustomContext.json',
+    'https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json',
+  ],
+  type: [
+    'VerifiableCredential',
+    'OpenAttestationCredential',
+    'DrivingLicenceCredential',
+    'OpenAttestationCredential',
+  ],
+  issuanceDate: '2023-06-07T04:47:41.451Z',
+  credentialSubject: {
+    id: 'did:ethr:0x02f6b75650805b93c9df9514e36302e8ad9ae1fbd8aeeb1163b7259dc2971dd3c2',
+    name: 'Alice',
+  },
+  credentialStatus: {
+    type: 'EthrStatusRegistry2019',
+    id: 'goerli:0x97fd27892cdcD035dAe1fe71235c636044B59348',
+  },
+  openAttestationMetadata: {
+    proof: {
+      type: 'OpenAttestationProofMethod',
+      method: 'DID',
+      value:
+        'did:ethr:0x02f6b75650805b93c9df9514e36302e8ad9ae1fbd8aeeb1163b7259dc2971dd3c2',
+      revocation: { type: 'NONE' },
+    },
+    identityProof: {
+      type: 'DID',
+      identifier:
+        'did:ethr:0x02f6b75650805b93c9df9514e36302e8ad9ae1fbd8aeeb1163b7259dc2971dd3c2',
+    },
+  },
+};
+
+export const INVALID_RAW_OA_CREDENTIAL = {
+  issuer: {
+    id: 'did:ethr:0x02f6b75650805b93c9df9514e36302e8ad9ae1fbd8aeeb1163b7259dc2971dd3c2',
+    name: 'GoSource Pty Ltd',
+    type: 'OpenAttestationIssuer',
+  },
+  '@context': [
+    'https://www.w3.org/2018/credentials/v1',
+    'https://schemata.openattestation.com/com/openattestation/1.0/DrivingLicenceCredential.json',
+    'https://schemata.openattestation.com/com/openattestation/1.0/CustomContext.json',
+    'https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json',
+  ],
+  type: [
+    'VerifiableCredential',
+    'OpenAttestationCredential',
+    'DrivingLicenceCredential',
+    'OpenAttestationCredential',
+  ],
+  issuanceDate: '2023-06-07T04:47:41.451Z',
+  credentialSubject: {
+    id: 'did:ethr:0x02f6b75650805b93c9df9514e36302e8ad9ae1fbd8aeeb1163b7259dc2971dd3c2',
+    name: 'Alice',
+  },
+  credentialStatus: {
+    type: 'EthrStatusRegistry2019',
+    id: 'goerli:0x97fd27892cdcD035dAe1fe71235c636044B59348',
+  },
+};
+
+export const SIGNED_WRAPPED_DOCUMENT = {
+  version: 'https://schema.openattestation.com/3.0/schema.json',
+  issuer: {
+    id: 'did:ethr:0x02f6b75650805b93c9df9514e36302e8ad9ae1fbd8aeeb1163b7259dc2971dd3c2',
+    name: 'GoSource Pty Ltd',
+    type: 'OpenAttestationIssuer',
+  },
+  '@context': [
+    'https://www.w3.org/2018/credentials/v1',
+    'https://schemata.openattestation.com/com/openattestation/1.0/DrivingLicenceCredential.json',
+    'https://schemata.openattestation.com/com/openattestation/1.0/CustomContext.json',
+    'https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json',
+  ],
+  type: [
+    'VerifiableCredential',
+    'OpenAttestationCredential',
+    'DrivingLicenceCredential',
+    'OpenAttestationCredential',
+  ],
+  issuanceDate: '2023-06-07T03:09:50.151Z',
+  credentialSubject: {
+    id: 'did:ethr:0x02f6b75650805b93c9df9514e36302e8ad9ae1fbd8aeeb1163b7259dc2971dd3c2',
+    name: 'Alice',
+  },
+  credentialStatus: {
+    type: 'EthrStatusRegistry2019',
+    id: 'goerli:0x97fd27892cdcD035dAe1fe71235c636044B59348',
+  },
+  openAttestationMetadata: {
+    proof: {
+      type: 'OpenAttestationProofMethod',
+      method: 'DID',
+      value:
+        'did:ethr:0x02f6b75650805b93c9df9514e36302e8ad9ae1fbd8aeeb1163b7259dc2971dd3c2',
+      revocation: { type: 'NONE' },
+    },
+    identityProof: {
+      type: 'DID',
+      identifier:
+        'did:ethr:0x02f6b75650805b93c9df9514e36302e8ad9ae1fbd8aeeb1163b7259dc2971dd3c2',
+    },
+  },
+  proof: {
+    type: 'OpenAttestationMerkleProofSignature2018',
+    proofPurpose: 'assertionMethod',
+    targetHash:
+      '39b632cd639d2648790a7a4b7e911557cefd497e95483fec503af5ac69179577',
+    proofs: [],
+    merkleRoot:
+      '39b632cd639d2648790a7a4b7e911557cefd497e95483fec503af5ac69179577',
+    salts:
+      'W3sidmFsdWUiOiIwNjg1MThhNDBlYmZhYTM3NjFjNWJhNzYyNjczMTNkMTBmM2FhMmVmNWNiN2YzZDc0ZmY0MjI5Yjc4MDAyZDA2IiwicGF0aCI6InZlcnNpb24ifSx7InZhbHVlIjoiYTkzNmUwYTU1MWY2YWU5ZTgzM2ZmMGU2ZTJkNDY5ZTI3ZjU3MjljMTg4NDEyOGRlYzdjM2RhZGI2ODgzYTNjNCIsInBhdGgiOiJpc3N1ZXIuaWQifSx7InZhbHVlIjoiMzUyZmQzNTdlZjFhNjZhODU1Mjk0MDM2YWIzYmE3NGM3YjU0Njg1MmM4M2JlMTFkYjNjYWFlMTgyMzM0N2Y2NyIsInBhdGgiOiJpc3N1ZXIubmFtZSJ9LHsidmFsdWUiOiI3MDdhNGViOTg0NGQ1YWY3NDQwOWJmOWRkOWZlOTkzMTBjZjI1NmQ1OTFmNjcwZjc5MGZlZTgxOGQ1M2I4NGRiIiwicGF0aCI6Imlzc3Vlci50eXBlIn0seyJ2YWx1ZSI6IjQ0YjBmZmQzNDJiMzNkNWFhNmQ4N2M4NDJhMTdhZDlhZDUxNGUzMGI0OTM4NjFhZjk5M2VmOTBhM2MwMWU4MWIiLCJwYXRoIjoiQGNvbnRleHRbMF0ifSx7InZhbHVlIjoiY2IzNmNiYTgyMjgxMzcyYWI3NjE4ODY1MmZhYzNjZTYxYTIzMWU3MDgzNGY4ZDJlYTRlOWM0MzBhZjAyYTkyNiIsInBhdGgiOiJAY29udGV4dFsxXSJ9LHsidmFsdWUiOiIxNDNmNWQyOWMyNDI5MGVlNGVjOGVkNDYyMmFiYzJiOGFmMjRmNTYyMjg5MTEwMGQzZmRmMjllNTQ2ZDhhZWZlIiwicGF0aCI6IkBjb250ZXh0WzJdIn0seyJ2YWx1ZSI6IjI0NDQ5N2QzOTk2MWU3MmJmNGIzZDliZGZmNmRhZjc3ZWJiZGJiZmYxZTM3NmQwM2RiOTk1NThmY2FmODgwYTciLCJwYXRoIjoiQGNvbnRleHRbM10ifSx7InZhbHVlIjoiODk4OTQzYTg5Y2ExMWM0MDM0ZmQyNGQxN2ExNzRmZWI4NTNiM2E5ODM3YWNhNmZiMTliM2U4Njc2Y2U0ZDI5OCIsInBhdGgiOiJ0eXBlWzBdIn0seyJ2YWx1ZSI6ImJlOGEyYjE0MmM0NGRlMTA4MGZiMTQzMjJhNDBkYzlhYzdmMjA4ZDAwNTI0NTRjOWNhYzEyYzE3YjVlYmRmOTciLCJwYXRoIjoidHlwZVsxXSJ9LHsidmFsdWUiOiIyMTZkNDIzOWJkYjQ3NTFmNjQzYTUxNWQxM2Q0YjgyNjAxZTY5ODU5ZjMwNzk3MjExODliZmZhNzY3ZjQ4N2ZmIiwicGF0aCI6InR5cGVbMl0ifSx7InZhbHVlIjoiZjVhNWI0MmZiZmE5YmQ0ZGUzOWI3N2MwZDRjMjY4MmE2OGI0MWExOTE4YjRjN2RhNTY5ZDUxZGM2MDYyZDY4NSIsInBhdGgiOiJ0eXBlWzNdIn0seyJ2YWx1ZSI6IjgwOTc0MTdiMzQ2ODkyZjYxZTJlOGI4ZWI0ZDVjOGI1YjZkMTI1ZjUxMmVmZGM4N2RmZTgwMTdiMTJjYTE0NDYiLCJwYXRoIjoiaXNzdWFuY2VEYXRlIn0seyJ2YWx1ZSI6ImE0ZWU3ZWFiZTVhOWY5YTcxYzE3NTMzMWExNmFkOGU2ZTM3ZTY3ZjNkZGFlZjVjNTU0MTEzYWVmMzQzZTUyOTYiLCJwYXRoIjoiY3JlZGVudGlhbFN1YmplY3QuaWQifSx7InZhbHVlIjoiMzM2MDFiYWYzODlhOTkyZGIxMWFkZGU3ZmQ5M2U5Y2M1ZTI4ZWY2MmNkNGE5YTFlY2UxMmI0MDliMzQyZWJlOSIsInBhdGgiOiJjcmVkZW50aWFsU3ViamVjdC5uYW1lIn0seyJ2YWx1ZSI6IjU4MjNmYjdjOTFjYWYzYTkzNzcwNmFjYWMzOWQyYzFmZTJjZTZhM2QxNjA4ZWQ5ZWMxZWJmODJjODM5MDI4YzkiLCJwYXRoIjoiY3JlZGVudGlhbFN0YXR1cy50eXBlIn0seyJ2YWx1ZSI6ImQ2MTZhNjQ2YmRlYzcwOWM1ODE0MWNjNzNiMmY1Yzc3YTIwZmNjMWUwZmExYWE5NDVkYjEwOTA1ZDkxN2VlN2UiLCJwYXRoIjoiY3JlZGVudGlhbFN0YXR1cy5pZCJ9LHsidmFsdWUiOiI4NmY5YzM3NDBmY2Y0ZWYwYjgzNGZlZjg2MTZlYTg4ZGY4YjI1MzlkZWE3MzFmM2RjMWE3ZTBhMmRjMTZhZTgyIiwicGF0aCI6Im9wZW5BdHRlc3RhdGlvbk1ldGFkYXRhLnByb29mLnR5cGUifSx7InZhbHVlIjoiN2VhZjZiM2I1MTc4ZjIwYjRmMTZkZDdjNTA1NTgyMTM3NjY2YTkxYmUyMjAxZmJiNzc2YTQ0Njk2YjRjMTI0MyIsInBhdGgiOiJvcGVuQXR0ZXN0YXRpb25NZXRhZGF0YS5wcm9vZi5tZXRob2QifSx7InZhbHVlIjoiYTA2ODQyYWRhOWU0OTBjOTc1NWZmNzVmMzIzZGZlYTk4ODNlZTgwMjM5NWY0ZjM0NWE1Mjg5ZWVjNGE1MzcxMSIsInBhdGgiOiJvcGVuQXR0ZXN0YXRpb25NZXRhZGF0YS5wcm9vZi52YWx1ZSJ9LHsidmFsdWUiOiJkMTVlM2U3MjliYzk3YzVhYmE4MjVmYzUxMGE5N2JkNjE5YjZiZjcxMzQzMzFiNTQwY2UwODk4MDBiNjM0NTc0IiwicGF0aCI6Im9wZW5BdHRlc3RhdGlvbk1ldGFkYXRhLnByb29mLnJldm9jYXRpb24udHlwZSJ9LHsidmFsdWUiOiJmYTNiZDFlM2Q3YTM1MmUwMDEyYzQwMmM2ODQxN2MwNDI1ZTc4OGYyNjQxYzBjZjRkZmM1ZDk2NzNiMWI0ZDFmIiwicGF0aCI6Im9wZW5BdHRlc3RhdGlvbk1ldGFkYXRhLmlkZW50aXR5UHJvb2YudHlwZSJ9LHsidmFsdWUiOiJkY2JmMTQzN2Y1NGViZjg4NmVjNTU5YWU2OTQ5YTQ1YTAzYWY4NzRlNWJiYzQ2MjdiZmFlMTEyMjFiMTY1Y2I5IiwicGF0aCI6Im9wZW5BdHRlc3RhdGlvbk1ldGFkYXRhLmlkZW50aXR5UHJvb2YuaWRlbnRpZmllciJ9XQ==',
+    privacy: { obfuscated: [] },
+    key: 'did:ethr:0x02f6b75650805b93c9df9514e36302e8ad9ae1fbd8aeeb1163b7259dc2971dd3c2#controller',
+    signature:
+      '0xc1cf3aa8b11c638e37b3cc8d8df996f9f7fb618852ca7392adcbb4f4cbdfd9180eef177aa9b8dd468c1e6ee5a6c560ba9a9910bb10eb89c2dac1782939c2d25d1b',
+  },
+};

--- a/packages/credential-oa/api-extractor.json
+++ b/packages/credential-oa/api-extractor.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "apiReport": {
+    "enabled": true,
+    "reportFolder": "./api",
+    "reportTempFolder": "./api"
+  },
+
+  "docModel": {
+    "enabled": true,
+    "apiJsonFilePath": "./api/<unscopedPackageName>.api.json"
+  },
+
+  "dtsRollup": {
+    "enabled": false
+  },
+  "mainEntryPointFilePath": "<projectFolder>/build/index.d.ts"
+}

--- a/packages/credential-oa/package.json
+++ b/packages/credential-oa/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@vckit/credential-oa",
+  "description": "vckit plugin for working with OpenAttestation Verifiable Credentials & Presentations.",
+  "version": "1.0.0-beta.2",
+  "main": "build/index.js",
+  "exports": {
+    ".": "./build/index.js",
+    "./build/plugin.schema.json": "./build/plugin.schema.json"
+  },
+  "types": "build/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -b --watch",
+    "extract-api": "node ../cli/bin/vckit.js dev extract-api"
+  },
+  "dependencies": {
+    "@govtechsg/oa-verify": "^8.0.0",
+    "@govtechsg/open-attestation": "^6.6.0",
+    "@vckit/core-types": "^1.0.0-beta.2",
+    "@veramo/message-handler": "^5.1.2",
+    "@veramo/utils": "^5.1.2"
+  },
+  "devDependencies": {
+    "@types/debug": "4.1.7",
+    "@types/uuid": "9.0.0",
+    "typescript": "4.9.4"
+  },
+  "files": [
+    "build/**/*",
+    "src/**/*",
+    "plugin.schema.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": "git@github.com:uncefact/project-vckit.git",
+  "author": "Toan Ngo toan.ngo@gosource.com.au",
+  "contributors": [
+    "Nam Hoang <nam.hoang@gosource.com.au>"
+  ],
+  "license": "Apache-2.0",
+  "keywords": [],
+  "type": "module",
+  "moduleDirectories": [
+    "node_modules",
+    "src"
+  ]
+}

--- a/packages/credential-oa/src/action-handler.ts
+++ b/packages/credential-oa/src/action-handler.ts
@@ -1,0 +1,155 @@
+import {
+  IAgentContext,
+  IAgentPlugin,
+  ICreateVerifiableCredentialArgs,
+  IIdentifier,
+  IKey,
+  IKeyManager,
+  IOACredentialPlugin,
+  IssuerAgentContext,
+  IVerifyCredentialArgs,
+  IVerifyResult,
+  VerifiableCredential,
+  VerifierAgentContext,
+} from '@vckit/core-types';
+
+import {
+  __unsafe__use__it__at__your__own__risks__wrapDocument,
+  OpenAttestationDocument,
+  utils,
+  WrappedDocument,
+} from '@govtechsg/open-attestation';
+
+import {
+  extractIssuer,
+  MANDATORY_CREDENTIAL_CONTEXT,
+  processEntryToArray,
+} from '@veramo/utils';
+
+import { isValid, verify } from '@govtechsg/oa-verify';
+
+const OA_MANDATORY_CREDENTIAL_CONTEXT =
+  'https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json';
+
+const OA_MANDATORY_CREDENTIAL_TYPES = [
+  'VerifiableCredential',
+  'OpenAttestationCredential',
+];
+
+/**
+ 
+ * @public
+ */
+export class CredentialPlugin implements IAgentPlugin {
+  readonly methods: IOACredentialPlugin;
+
+  constructor() {
+    this.methods = {
+      createVerifiableCredentialOA:
+        this.createVerifiableCredentialOA.bind(this),
+      verifyCredentialOA: this.verifyCredentialOA.bind(this),
+    };
+  }
+
+  /** {@inheritdoc @veramo/core-types#ICredentialIssuer.createVerifiableCredential} */
+  async createVerifiableCredentialOA(
+    args: ICreateVerifiableCredentialArgs,
+    context: IssuerAgentContext
+  ): Promise<VerifiableCredential> {
+    const { credential: credentialInput } = args;
+
+    const credentialContext = processEntryToArray(
+      credentialInput['@context'],
+      MANDATORY_CREDENTIAL_CONTEXT
+    );
+
+    const credentialType = processEntryToArray(credentialInput.type);
+
+    const credential = {
+      ...credentialInput,
+      '@context': [...credentialContext, OA_MANDATORY_CREDENTIAL_CONTEXT],
+      type: [...credentialType, ...OA_MANDATORY_CREDENTIAL_TYPES],
+    };
+
+    let wrappedDocument;
+    try {
+      wrappedDocument =
+        //@ts-ignore
+        await __unsafe__use__it__at__your__own__risks__wrapDocument(credential);
+    } catch (e) {
+      throw new Error(
+        `invalid_argument: credential is not a valid OpenAttestation document`
+      );
+    }
+
+    const issuer = extractIssuer(credential);
+
+    let identifier: IIdentifier;
+    try {
+      identifier = await context.agent.didManagerGet({ did: issuer });
+    } catch (e) {
+      throw new Error(`invalid_argument: did not found in the DID manager`);
+    }
+
+    const key = identifier.keys.find((k) => k.type === 'Secp256k1');
+    if (!key) {
+      throw Error('No signing key for ' + identifier.did);
+    }
+
+    const signer = wrapSigner(context, key, 'eth_signMessage');
+
+    const signature = await signer(`0x${wrappedDocument.proof.merkleRoot}`);
+
+    const verifiableCredential: VerifiableCredential = {
+      ...wrappedDocument,
+      proof: {
+        ...wrappedDocument.proof,
+        key: `${identifier.did}#controller`,
+        signature,
+      },
+    };
+
+    return verifiableCredential;
+  }
+
+  /** {@inheritdoc @veramo/core-types#ICredentialVerifier.verifyCredential} */
+  async verifyCredentialOA(
+    args: IVerifyCredentialArgs,
+    context: VerifierAgentContext
+  ): Promise<IVerifyResult> {
+    try {
+      const { credential } = args;
+
+      if (!utils.isSignedWrappedV3Document(credential)) {
+        throw new Error(
+          'invalid_argument: credential must be a signed wrapped v3 document'
+        );
+      }
+
+      const fragments = await verify(credential);
+
+      return {
+        verified: isValid(fragments),
+      };
+    } catch (error) {
+      return {
+        verified: false,
+        error,
+      };
+    }
+  }
+}
+
+const wrapSigner = (
+  context: IAgentContext<Pick<IKeyManager, 'keyManagerSign'>>,
+  key: IKey,
+  algorithm?: string
+) => {
+  return (data: string | Uint8Array): Promise<string> =>
+    context.agent.keyManagerSign({
+      keyRef: key.kid,
+      data: <string>data,
+      algorithm,
+      encoding: 'hex',
+    });
+};

--- a/packages/credential-oa/src/index.ts
+++ b/packages/credential-oa/src/index.ts
@@ -1,0 +1,1 @@
+export { CredentialPlugin } from './action-handler.js';

--- a/packages/credential-oa/tsconfig.json
+++ b/packages/credential-oa/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.settings.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build",
+    "declarationDir": "build",
+    // https://github.com/transmute-industries/vc.js/issues/60
+    "skipLibCheck": true
+  },
+  "references": [
+    { "path": "../core-types" }
+  ],
+  "include": ["./**/*.ts", "./src/plugin.schema.json"]
+}


### PR DESCRIPTION
# Description

- This plugin is used for issuing and verifying verifiable credential that conform to Open Attestation framework
- `uncefact/project-vckit` ’s goals is to support issuing and verifying verifiable credential in both W3C and Open Atttestation framework  , so this plugin is packed inside `uncefact/project-vckit` core but it can be plugged into any platform/library that using Veramo architecture.

# Issue
- #78 

# Changes
- [x] create new package `credential-oa`
- [x] create new interface inherited from Veramon 
-  [x] implement ICredentialPlugin
- [x] write unit tests
- [x] write docs

# Note 
- Right now the plugin only support `did:ethr` type for signing and identity verification. 