### PR TITLE
chore: set up eslint and git hook

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,67 +1,34 @@
 {
-  "root": true,
-  "plugins": ["@nrwl/nx", "@typescript-eslint"],
-  "parser": "@typescript-eslint/parser",
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking"
-  ],
-  "parserOptions": {
-    "project": ["tsconfig.base.json"]
-  },
-  "overrides": [
-    {
-      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-      "rules": {
-        "@nrwl/nx/enforce-module-boundaries": [
-          "error",
-          {
-            "enforceBuildableLibDependency": true,
-            "allow": ["api-interfaces"],
-            "depConstraints": [
-              {
-                "sourceTag": "*",
-                "onlyDependOnLibsWithTags": ["*"]
-              }
-            ]
-          }
+    "env": {
+        "browser": true,
+        "es2021": true
+    },
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+    "plugins": [
+        "@typescript-eslint"
+    ],
+    "rules": {
+        "@typescript-eslint/ban-ts-ignore": "off",
+        "@typescript-eslint/ban-ts-comment": "off",
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
         ]
-      }
-    },
-    {
-      "files": ["*.ts", "*.tsx"],
-      "extends": ["plugin:@nrwl/nx/typescript"],
-      "rules": {}
-    },
-    {
-      "files": ["*.js", "*.jsx"],
-      "extends": ["plugin:@nrwl/nx/javascript"],
-      "rules": {}
-    },
-    {
-      "files": [
-        "*.spec.ts",
-        "*.spec.tsx",
-        "*.spec.js",
-        "*.spec.jsx",
-        "*.test.ts",
-        "*.test.tsx",
-        "*.test.js",
-        "*.test.jsx"
-      ],
-      "env": {
-        "jest": true
-      },
-      "rules": {
-        "@typescript-eslint/unbound-method": "off"
-      }
     }
-  ],
-  "rules": {
-    "no-console": "warn",
-    "@typescript-eslint/no-unsafe-call": "off",
-    "@typescript-eslint/no-unsafe-member-access": "off",
-    "@typescript-eslint/no-unsafe-assignment": "off"
-  }
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+pnpm run lint

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "vckit": "cross-env NODE_NO_WARNINGS=1 ./packages/cli/bin/vckit.js",
     "prettier": "prettier --write \"{packages,docs,__tests__,!build}/**/*.{ts,js,json,md,yml}\"",
     "build-clean": "rimraf --glob ./packages/*/build ./packages/*/api ./packages/*/node_modules ./packages/*/tsconfig.tsbuildinfo ./temp ./tmp && jest --clearCache",
-    "version": "lerna version"
+    "version": "lerna version",
+    "lint": "lint-staged"
   },
   "devDependencies": {
     "@ethersproject/contracts": "^5.7.0",
@@ -39,12 +40,14 @@
     "ethr-did-resolver": "^8.0.0",
     "express": "^4.18.2",
     "ganache": "7.7.3",
+    "husky": "^8.0.3",
     "jest": "29.3.1",
     "jest-environment-jsdom": "29.3.1",
     "jest-environment-node": "29.3.1",
     "json-schema": "0.4.0",
     "lerna": "6.4.1",
     "lerna-changelog": "2.2.0",
+    "lint-staged": "^13.2.2",
     "oas-resolver": "2.5.6",
     "openapi-types": "12.1.0",
     "prettier": "2.8.3",
@@ -58,6 +61,9 @@
     "typescript": "4.9.4",
     "uint8arrays": "4.0.3",
     "web-did-resolver": "^2.0.23"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": "eslint --fix"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Issue
- #85 

# Changes
- [x]  set up linting and add git hook

# Screenshots
<img width="1029" alt="image" src="https://github.com/uncefact/project-vckit/assets/17349449/aff6aee8-b2d1-4187-b92a-0ade71d3c5a3">


# Note

- To make SourceTree to know the command inside .sh , add `~/.huskyrc` to load the necessary before running hooks.

```javascript
# This loads nvm.sh, sets the correct PATH before running hook, and ensures the project version of Node
export NVM_DIR="$HOME/.nvm"

[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"

# If you have an .nvmrc file, we use the relevant node version
if [[ -f ".nvmrc" ]]; then
  nvm use
fi
``` 
