### PR TITLE
chore: add publishConfig with public access to package.json files

### DIFF
--- a/packages/bitstringStatusList/package.json
+++ b/packages/bitstringStatusList/package.json
@@ -54,5 +54,8 @@
     "did-jwt": "^7.4.7",
     "typeorm": "^0.3.10",
     "uuid": "^9.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/oauth-middleware/package.json
+++ b/packages/oauth-middleware/package.json
@@ -42,5 +42,8 @@
   "moduleDirectories": [
     "node_modules",
     "src"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -25,5 +25,8 @@
   "dependencies": {
     "@uncefact/vckit-core-types": "workspace:1.0.0",
     "multiformats": "^13.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/vckit-oa-renderers/package.json
+++ b/packages/vckit-oa-renderers/package.json
@@ -221,5 +221,8 @@
   "moduleDirectories": [
     "node_modules",
     "src"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [x] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR adds the `publishConfig` field with public access to the package.json files of the following four packages:

- @uncefact/vckit-bitstringStatusList
- @uncefact/vckit-tools
- @uncefact/vckit-oa-renderers
- @uncefact/vckit-oauth-middleware

This ensures that these packages can be successfully published to npm.

## Related Tickets & Documents

https://github.com/gs-gs/fa-ag-trace/issues/956



## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [vc-kit doc site](https://uncefact.github.io/vckit/)
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?


<!-- note: PRs with deleted sections will be marked invalid -->

