### PR TITLE
docs(renderer): fix incorrect media type in enveloped credential examples

### DIFF
--- a/documentation/docs/vckit-plugins/renderer.md
+++ b/documentation/docs/vckit-plugins/renderer.md
@@ -86,7 +86,7 @@ import { WebRenderingTemplate2022 } from '@uncefact/vckit-renderer';
 const params = {
   credential: {
     '@context': ['https://www.w3.org/ns/credentials/v2', 'https://www.w3.org/ns/credentials/examples/v2'],
-    id: 'data:application/vc-ld+jwt,eyJhbGciOiJFZERTQSIsIm...', // The JWT should contain render field with the template.
+    id: 'data:application/vc+jwt,eyJhbGciOiJFZERTQSIsIm...', // The JWT should contain render field with the template.
     type: 'EnvelopedVerifiableCredential',
   },
 };

--- a/documentation/versioned_docs/version-1.0.0/vckit-plugins/renderer.md
+++ b/documentation/versioned_docs/version-1.0.0/vckit-plugins/renderer.md
@@ -86,7 +86,7 @@ import { WebRenderingTemplate2022 } from '@uncefact/vckit-renderer';
 const params = {
   credential: {
     '@context': ['https://www.w3.org/ns/credentials/v2', 'https://www.w3.org/ns/credentials/examples/v2'],
-    id: 'data:application/vc-ld+jwt,eyJhbGciOiJFZERTQSIsIm...', // The JWT should contain render field with the template.
+    id: 'data:application/vc+jwt,eyJhbGciOiJFZERTQSIsIm...', // The JWT should contain render field with the template.
     type: 'EnvelopedVerifiableCredential',
   },
 };

--- a/documentation/versioned_docs/version-1.0.1/vckit-plugins/renderer.md
+++ b/documentation/versioned_docs/version-1.0.1/vckit-plugins/renderer.md
@@ -86,7 +86,7 @@ import { WebRenderingTemplate2022 } from '@uncefact/vckit-renderer';
 const params = {
   credential: {
     '@context': ['https://www.w3.org/ns/credentials/v2', 'https://www.w3.org/ns/credentials/examples/v2'],
-    id: 'data:application/vc-ld+jwt,eyJhbGciOiJFZERTQSIsIm...', // The JWT should contain render field with the template.
+    id: 'data:application/vc+jwt,eyJhbGciOiJFZERTQSIsIm...', // The JWT should contain render field with the template.
     type: 'EnvelopedVerifiableCredential',
   },
 };


### PR DESCRIPTION
## Summary

- Corrects the media type used in the `EnvelopedVerifiableCredential` code examples across the renderer documentation
- Changes `application/vc-ld+jwt` → `application/vc+jwt` in current and versioned docs (v1.0.0, v1.0.1)

## Context

The renderer documentation examples used `application/vc-ld+jwt` as the media type in the enveloped credential data URI (`data:application/vc-ld+jwt,eyJ...`). This is a non-standard media type that does not match either the W3C specifications or what VCKit actually produces.

The correct media type is `application/vc+jwt`, as defined by:

- **W3C VC-JOSE-COSE**, Section 6.1 — Media Types: https://www.w3.org/TR/vc-jose-cose/#media-types
- **W3C VCDM 2.0**, Appendix C — IANA Considerations: https://www.w3.org/TR/vc-data-model-2.0/#iana-considerations
- **W3C VCDM 2.0**, Section 4.11 — Securing Mechanisms (Enveloped Verifiable Credentials): https://www.w3.org/TR/vc-data-model-2.0/#enveloped-verifiable-credentials

The Veramo fork (`gs-gs/veramo`, branch `vc-v2`) sets `typ: 'vc+jwt'` in the JWT protected header when signing enveloped credentials, and constructs the data URI as `` `data:application/${header.typ},${jwt}` ``, producing `data:application/vc+jwt,...` — confirming the docs were out of sync with the implementation.

## Test plan

- [x] Verified the media type matches the W3C VC-JOSE-COSE spec
- [x] Verified the media type matches what the Veramo fork produces in `kms-local/src/key-management-system.ts` and `credential-w3c/src/action-handler.ts`