### PR TITLE
fix(cli): exit with non-zero code when did import fails

### DIFF
--- a/packages/cli/src/did.ts
+++ b/packages/cli/src/did.ts
@@ -78,6 +78,7 @@ did
       printTable([{ provider: identifier.provider, alias: identifier.alias, did: identifier.did }])
     } catch (e: any) {
       console.error(e.message)
+      process.exitCode = 1
     }
   })
 
@@ -105,6 +106,7 @@ did
       console.log('Success:', result)
     } catch (e: any) {
       console.error(e)
+      process.exitCode = 1
     }
   })
 
@@ -153,6 +155,7 @@ did
       console.log('Success:', result)
     } catch (e: any) {
       console.error(e)
+      process.exitCode = 1
     }
   })
 
@@ -186,6 +189,7 @@ did
       console.log('Success:', result)
     } catch (e: any) {
       console.error(e)
+      process.exitCode = 1
     }
   })
 
@@ -232,6 +236,7 @@ did
       console.log('Success:', result)
     } catch (e: any) {
       console.error(e)
+      process.exitCode = 1
     }
   })
 
@@ -265,6 +270,7 @@ did
       console.log('Success:', result)
     } catch (e: any) {
       console.error(e)
+      process.exitCode = 1
     }
   })
 
@@ -293,6 +299,7 @@ did
       console.log(JSON.stringify(identifier))
     } catch (e: any) {
       console.error(e)
+      process.exitCode = 1
     }
   })
 
@@ -315,6 +322,7 @@ did
       console.log(identifier)
     } catch (e: any) {
       console.error(e)
+      process.exitCode = 1
     }
   })
 
@@ -328,6 +336,7 @@ did
       console.log(JSON.stringify(ddo, null, 2))
     } catch (e: any) {
       console.error(e.message)
+      process.exitCode = 1
     }
   })
 


### PR DESCRIPTION
The `did import` CLI command caught errors and logged them to stderr but always exited with code 0. This made it impossible for callers to detect failures. The Docker entrypoint's error guard (`|| exit 1` from PR #291) was ineffective because the CLI never signalled failure via exit code.

Closes #293

## Test plan
- [x] `echo "not json" | node packages/cli/build/cli.js did import` now exits with code 1
- [x] Valid JSON with missing fields exits with code 1
- [x] Successful import still exits with code 0